### PR TITLE
Adding null coalescing operator for default value

### DIFF
--- a/src/js/utils.mjs
+++ b/src/js/utils.mjs
@@ -7,7 +7,7 @@ export function qs(selector, parent = document) {
 
 // retrieve data from localstorage
 export function getLocalStorage(key) {
-  return JSON.parse(localStorage.getItem(key));
+  return JSON.parse(localStorage.getItem(key)) ?? [];
 }
 // save data to local storage
 export function setLocalStorage(key, data) {


### PR DESCRIPTION
I added a null coalescing operator to the return statement of getLocalStorage() so it return an empty array instead of a null value when not finding any data on the storage.