### PR TITLE
Fix addToCart Errors

### DIFF
--- a/src/js/ProductDetails.mjs
+++ b/src/js/ProductDetails.mjs
@@ -13,9 +13,10 @@ export default class productDetails {
   async init() {
     this.product = await this.dataSource.findProductById(this.productId);
     this.renderProductDetails(this.product);
+    const addCart = this.addToCart.bind(this)
     document
       .getElementById("addToCart")
-      .addEventListener("click", () => this.addToCart(this.product).bind(this));
+      .addEventListener("click", () => addCart(this.product));
   }
 
   addToCart(product) {

--- a/src/js/ProductDetails.mjs
+++ b/src/js/ProductDetails.mjs
@@ -15,7 +15,7 @@ export default class productDetails {
     this.renderProductDetails(this.product);
     document
       .getElementById("addToCart")
-      .addEventListener("click", this.addToCart(this.product).bind(this));
+      .addEventListener("click", () => this.addToCart(this.product).bind(this));
   }
 
   addToCart(product) {


### PR DESCRIPTION
The event listener for the addToCart button was broken due to the way the callback function was written. This fix rewrites the callback and also binds the `addCart` function so we can bind `this` to `productDetails` within the the callback to avoid a typeError.

See the new change here:
![image](https://user-images.githubusercontent.com/104602457/215901332-2549422b-c2a7-47ef-9d4c-2ca75f9f9ec7.png)
